### PR TITLE
Add APort to prompt injection defense tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ A research proposal to mitigate prompt injection by concatenating user generated
 | [NVIDIA/NeMo-Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | Guardrails | open-source toolkit for easily adding programmable guardrails to LLM-based conversational applications |
 | [amoffat/HeimdaLLM](https://github.com/amoffat/HeimdaLLM) | Output overseer | robust static analysis framework for validating that LLM-generated structured output is safe. It currently supports SQL |
 | [guardrails-ai/guardrails](https://github.com/guardrails-ai/guardrails) | Guardrails | Input/Output Guards that detect, quantify and mitigate the presence of specific types of risks |
+| [APort](https://aport.io) | Action guard / policy enforcement | Agent identity verification and pre-action authorization guardrails for sensitive LLM tool calls |
 | [whylabs/langkit](https://github.com/whylabs/langkit) | Input Overseer, Output Overseer | open-source toolkit for monitoring Large Language Models |
 | [ibm-granite/granite-guardian](https://github.com/ibm-granite/granite-guardian) | Guardrails | Input/Output guardrails, detecting risks in prompts, responses, RAG, and agentic workflows  |
 


### PR DESCRIPTION
## Problem
APort is missing from the prompt injection defense tools list, even though it fits the action-guard and policy-enforcement pattern for sensitive LLM tool calls.

## Summary
- Added APort to the Tools table.
- Described it as pre-action authorization and policy enforcement for agent tool calls.

## Verification
- Verified https://aport.io returns HTTP 200.
- Updated only the README Tools table.

## Bounty
Related bounty issue: https://github.com/aporthq/aport-integrations/issues/19

Payment details if this PR qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y